### PR TITLE
Make it easier to run on localhost.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,11 @@ On Windows one needs to use [Git Bash](https://git-scm.com/download/win) or equi
 You will also need to copy the Thali_CordovaPlugin 'mockmobile.js' script if you want run in development mode. This allows native methods to be called on the desktop when UX testing the web app.
 ```
 cd www/jxcore
+jx npm install --production --autoremove "*.gz"
+bower install
+find ./bower_components -name "*.gz" -type f -delete
 cp -v ../../thaliDontCheckIn/Thali_CordovaPlugin-master/test/www/jxcore/bv_tests/mockmobile.js node_modules/thali/
+jx npm run localhost
 ```
 
 # Fun issues you are probably going to run into

--- a/www/jxcore/app.js
+++ b/www/jxcore/app.js
@@ -14,10 +14,12 @@ app.disable('x-powered-by');
 var dbPath = path.join(os.tmpdir(), 'dbPath');
 
 var env = process.env.NODE_ENV || 'production'; // default to production
-if ('development' === env) {
-  console.log('localhost "' + app.get('env') + '" environment. ' + dbPath);
-  //var mockMobile = require('thali/mockmobile.js'); // uncomment for localhost testing
-} else if (process.platform === 'ios' || process.platform === 'android') {
+
+if (process.env.MOCK_MOBILE) {
+  global.Mobile = require('thali/mockmobile.js');
+}
+
+if (process.platform === 'ios' || process.platform === 'android') {
   Mobile.getDocumentsPath(function(err, location) {
     if (err) {
       console.error("Error", err);

--- a/www/jxcore/package.json
+++ b/www/jxcore/package.json
@@ -17,8 +17,6 @@
   "author": "",
   "license": "MIT",
   "scripts": {
-    "start": "NODE_ENV=development jx ./app.js"
+    "localhost": "MOCK_MOBILE=true NODE_ENV=development jx ./app.js"
   }
 }
-
-        


### PR DESCRIPTION
The main fix is to assign the mock object to `global.Mobile` rather than
to defining it with `var Mobile`, because otherwise, the definition would apply
only within the current module.

The trigger for the mockups was moved behind a more explicit MOCK_MOBILE
environment variable rather than NODE_ENV, because the latter is a fairly
commonly used and we don't want these mocks to accidentally apply, for example,
in a Cordova-based environment.

The readme is updated with steps needed after a fresh clone to be able to run
on localhost.

Fixes #58.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thaliproject/postcardapp/59)

<!-- Reviewable:end -->
